### PR TITLE
feat: expose transactions in PlayerSeason

### DIFF
--- a/integration-tests/__snapshots__/integration.test.js.snap
+++ b/integration-tests/__snapshots__/integration.test.js.snap
@@ -46197,6 +46197,7 @@ PlayerSeason {
     "points": null,
     "stats": null,
   },
+  "transactions": null,
   "weeklyActual": Object {},
 }
 `;
@@ -46266,6 +46267,7 @@ PlayerSeason {
       "usesPoints": false,
     },
   },
+  "transactions": null,
   "weeklyActual": Object {
     "1": Object {
       "points": PlayerStats {
@@ -46583,6 +46585,17 @@ PlayerSeason {
       "usesPoints": false,
     },
   },
+  "transactions": Array [
+    Transaction {
+      "action": "DRAFT",
+      "cost": 51,
+      "fromTeamId": 0,
+      "id": "a7fc7604-4eee-4eae-b3d2-f59133cfd664",
+      "isKeeper": false,
+      "scoringPeriodId": 1,
+      "toTeamId": 5,
+    },
+  ],
   "weeklyActual": Object {
     "1": Object {
       "points": PlayerStats {
@@ -46864,6 +46877,17 @@ PlayerSeason {
     "points": null,
     "stats": null,
   },
+  "transactions": Array [
+    Transaction {
+      "action": "DRAFT",
+      "cost": 46,
+      "fromTeamId": 0,
+      "id": "52905cf1-c906-4a79-a91c-7975c397fdd0",
+      "isKeeper": false,
+      "scoringPeriodId": 1,
+      "toTeamId": 4,
+    },
+  ],
   "weeklyActual": Object {
     "1": Object {
       "points": PlayerStats {

--- a/src/player-season/player-season.js
+++ b/src/player-season/player-season.js
@@ -8,6 +8,7 @@ import {
   statSources,
   maxScoringPeriodId
 } from '../constants.js';
+import Transaction from '../transaction/transaction';
 
 /* global PlayerStatsBundle */
 
@@ -122,6 +123,17 @@ class PlayerSeason extends BaseObject {
           }
         }
         return weeklyData;
+      }
+    },
+    transactions: {
+      key: 'transactions',
+      manualParse: (responseData, data) => {
+        if (!responseData) {
+          return null;
+        }
+        return responseData.map((transaction) => (
+          Transaction.buildFromServer(transaction, { playerId: data.player.id })
+        ));
       }
     }
   };

--- a/src/player-season/player-season.test.js
+++ b/src/player-season/player-season.test.js
@@ -82,13 +82,56 @@ describe('PlayerSeason', () => {
 
       data = {
         player: {
+          id: 12483,
           stats: [
             seasonProjectedStats,
             seasonActualStats,
             weeklyActualStats1,
             weeklyActualStats2
           ]
-        }
+        },
+        transactions: [
+          {
+            bidAmount: 2,
+            id: 'b286e9e8-e8f3-445b-90c8-eed71719e265',
+            items: [
+              {
+                fromTeamId: 0,
+                isKeeper: false,
+                overallPickNumber: 84,
+                playerId: 12483,
+                toTeamId: 2,
+                type: 'DRAFT'
+              }
+            ],
+            scoringPeriodId: 1,
+            teamId: 2,
+            type: 'DRAFT'
+          },
+          {
+            bidAmount: 3,
+            id: '9fd6ce3a-6812-4714-9e49-8ad3d0d3434b',
+            items: [
+              {
+                fromTeamId: 0,
+                isKeeper: false,
+                playerId: -16026,
+                toTeamId: 2,
+                type: 'ADD'
+              },
+              {
+                fromTeamId: 2,
+                isKeeper: false,
+                playerId: 12483,
+                toTeamId: 0,
+                type: 'DROP'
+              }
+            ],
+            scoringPeriodId: 4,
+            teamId: 2,
+            type: 'WAIVER'
+          }
+        ]
       };
     });
 
@@ -140,6 +183,17 @@ describe('PlayerSeason', () => {
           expect(Object.keys(player.weeklyActual).length).toEqual(2);
           expect(player.weeklyActual[15].points.totalPoints).toEqual(3.1);
           expect(player.weeklyActual[16].points.totalPoints).toEqual(5.2);
+        });
+      });
+    });
+
+    describe('transactions', () => {
+      describe('manualParse', () => {
+        test('maps transactions to an array of Transaction instances', () => {
+          const player = buildPlayerSeason(data, { seasonId });
+          expect(player.transactions.length).toEqual(2);
+          expect(player.transactions[0].action).toEqual('DRAFT');
+          expect(player.transactions[1].action).toEqual('DROP');
         });
       });
     });

--- a/src/transaction/testdata/mixon.json
+++ b/src/transaction/testdata/mixon.json
@@ -1,0 +1,113 @@
+{
+    "playerId": 3116385,
+    "transactions": [
+        {
+            "bidAmount": 38,
+            "executionType": "EXECUTE",
+            "id": "cb0cd39a-8abe-4448-80f1-4fece3a4628f",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": true,
+                    "overallPickNumber": 11,
+                    "playerId": 3116385,
+                    "toLineupSlotId": 2,
+                    "toTeamId": 6,
+                    "type": "DRAFT"
+                }
+            ],
+            "proposedDate": 1599189715538,
+            "rating": 0,
+            "scoringPeriodId": 1,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 6,
+            "type": "DRAFT"
+        },
+        {
+            "bidAmount": 20,
+            "executionType": "PROCESS",
+            "id": "d7e9dc4f-9b55-49eb-aa9c-5719505648e0",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3051926,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 6,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 6,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3116385,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "NightlyLeagueUpdateTaskProcessor",
+            "processDate": 1608107084166,
+            "proposedDate": 1608107083696,
+            "rating": 0,
+            "relatedTransactionId": "2d302afb-4022-404d-b283-10cc51ad3440",
+            "scoringPeriodId": 15,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 1,
+            "teamId": 6,
+            "type": "WAIVER"
+        },
+        {
+            "bidAmount": 0,
+            "executionType": "EXECUTE",
+            "id": "cfe3c723-800e-4761-8654-b0c7e2f01eee",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3116385,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 10,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 10,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 2577654,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "{388AC86A-0E65-4502-B5C3-DDD8173F4B15}",
+            "proposedDate": 1608736544374,
+            "rating": 0,
+            "scoringPeriodId": 16,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 10,
+            "type": "FREEAGENT"
+        }
+    ]
+}

--- a/src/transaction/testdata/stafford.json
+++ b/src/transaction/testdata/stafford.json
@@ -1,0 +1,379 @@
+{
+    "playerId": 12483,
+    "transactions": [
+        {
+            "bidAmount": 2,
+            "executionType": "EXECUTE",
+            "id": "b286e9e8-e8f3-445b-90c8-eed71719e265",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 84,
+                    "playerId": 12483,
+                    "toLineupSlotId": 20,
+                    "toTeamId": 2,
+                    "type": "DRAFT"
+                }
+            ],
+            "proposedDate": 1599189715539,
+            "rating": 0,
+            "scoringPeriodId": 1,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 2,
+            "type": "DRAFT"
+        },
+        {
+            "bidAmount": 3,
+            "executionType": "PROCESS",
+            "id": "9fd6ce3a-6812-4714-9e49-8ad3d0d3434b",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": -16026,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 2,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 2,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "NightlyLeagueUpdateTaskProcessor",
+            "processDate": 1601449632414,
+            "proposedDate": 1601449632369,
+            "rating": 0,
+            "relatedTransactionId": "f54a3ac2-fa30-4483-a885-c946d181d387",
+            "scoringPeriodId": 4,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 1,
+            "teamId": 2,
+            "type": "WAIVER"
+        },
+        {
+            "bidAmount": 0,
+            "executionType": "EXECUTE",
+            "id": "964a76a6-f316-4af7-b00b-883d94fa96c5",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 8,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 8,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 16813,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "{56A039F6-D26C-4108-A039-F6D26C110855}",
+            "proposedDate": 1601741606973,
+            "rating": 0,
+            "scoringPeriodId": 4,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 8,
+            "type": "FREEAGENT"
+        },
+        {
+            "bidAmount": 2,
+            "executionType": "PROCESS",
+            "id": "51bdc075-625f-47ec-8c94-de3a870c84b5",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 2580,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 8,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 8,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "NightlyLeagueUpdateTaskProcessor",
+            "processDate": 1602057059861,
+            "proposedDate": 1602057059629,
+            "rating": 0,
+            "relatedTransactionId": "03f89b04-110a-4256-809f-aca7c9311f53",
+            "scoringPeriodId": 5,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 2,
+            "teamId": 8,
+            "type": "WAIVER"
+        },
+        {
+            "bidAmount": 21,
+            "executionType": "PROCESS",
+            "id": "615ed86b-f387-4136-9a14-48265296db5f",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 2,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 2,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 15349,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "NightlyLeagueUpdateTaskProcessor",
+            "processDate": 1602748671459,
+            "proposedDate": 1602748671316,
+            "rating": 0,
+            "relatedTransactionId": "d91adc51-45ad-4cbe-92c8-e20a3ce2251c",
+            "scoringPeriodId": 6,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 1,
+            "teamId": 2,
+            "type": "WAIVER"
+        },
+        {
+            "acceptedDate": 1602819578924,
+            "bidAmount": 0,
+            "executionType": "PROCESS",
+            "expirationDate": 1602992339007,
+            "id": "4f525632-bf58-4799-8596-926a6c6b8cdd",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": true,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 1,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3122840,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 2,
+                    "type": "TRADE"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 1,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 4241475,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 2,
+                    "type": "TRADE"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 2,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 1,
+                    "type": "TRADE"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 2,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 2574808,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 1,
+                    "type": "TRADE"
+                }
+            ],
+            "memberId": "{E1B1C749-EBBC-4C33-BCC0-D1B1C6F8B1D1}",
+            "processDate": 1602819578924,
+            "proposedDate": 1602819578812,
+            "rating": 0,
+            "relatedTransactionId": "fe596996-5014-4ad1-9e9c-eee393c3125c",
+            "scoringPeriodId": 6,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamActions": {
+                "1": "ACCEPTED",
+                "2": "ACCEPTED"
+            },
+            "teamId": 2,
+            "type": "TRADE_ACCEPT"
+        },
+        {
+            "bidAmount": 0,
+            "executionType": "EXECUTE",
+            "id": "03cad1b5-0736-4c21-b4df-66d1d7d8210b",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3128429,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 1,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 1,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "{E1B1C749-EBBC-4C33-BCC0-D1B1C6F8B1D1}",
+            "proposedDate": 1603288354973,
+            "rating": 0,
+            "scoringPeriodId": 7,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 1,
+            "type": "FREEAGENT"
+        },
+        {
+            "bidAmount": 0,
+            "executionType": "EXECUTE",
+            "id": "7c966f1f-8070-48d6-b9a0-80a25b73e348",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 1,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 1,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 3128429,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "{E1B1C749-EBBC-4C33-BCC0-D1B1C6F8B1D1}",
+            "proposedDate": 1604501511705,
+            "rating": 0,
+            "scoringPeriodId": 9,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 1,
+            "type": "FREEAGENT"
+        },
+        {
+            "bidAmount": 0,
+            "executionType": "EXECUTE",
+            "id": "8147ff7c-98fa-4d9c-8cdc-669a1d750ece",
+            "isActingAsTeamOwner": false,
+            "isLeagueManager": false,
+            "isPending": false,
+            "items": [
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 0,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 4241475,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 1,
+                    "type": "ADD"
+                },
+                {
+                    "fromLineupSlotId": -1,
+                    "fromTeamId": 1,
+                    "isKeeper": false,
+                    "overallPickNumber": 0,
+                    "playerId": 12483,
+                    "toLineupSlotId": -1,
+                    "toTeamId": 0,
+                    "type": "DROP"
+                }
+            ],
+            "memberId": "{E1B1C749-EBBC-4C33-BCC0-D1B1C6F8B1D1}",
+            "proposedDate": 1604857916991,
+            "rating": 0,
+            "scoringPeriodId": 9,
+            "skipTransactionCounters": false,
+            "status": "EXECUTED",
+            "subOrder": 0,
+            "teamId": 1,
+            "type": "FREEAGENT"
+        }
+    ]
+}

--- a/src/transaction/transaction.js
+++ b/src/transaction/transaction.js
@@ -1,0 +1,80 @@
+import _ from 'lodash';
+
+import BaseObject from '../base-classes/base-object/base-object.js';
+
+/**
+ * Represents a player changing teams, for example due to add/drop, draft, or trade.
+ *
+ * @augments {BaseObject}
+ */
+class Transaction extends BaseObject {
+  constructor(options = {}) {
+    super(options);
+  }
+
+  static displayName = 'Transaction';
+
+  /**
+   * @typedef {object} Transaction~TransactionMap
+   *
+   * @property {number} id The id of the transaction in the ESPN universe.
+   * @property {number} cost The cost of the transaction, only if applicable.
+   * @property {number} scoringPeriodId The period in which this transaction took place.
+   * @property {number} action The means by which the transaction is taking place
+   *                           (DRAFT|ADD|DROP|TRADE).
+   * @property {number} fromTeamId The team the player is leaving, if applicable.
+   *                    0 indicates the player was "un-signed".
+   * @property {number} toTeamId The team the player is joining, if applicable.
+   *                    0 indicates the player was "un-signed".
+   * @property {number} isKeeper True if the player was drafted as a keeper from the previous year.
+   */
+
+  /**
+   * @type {Transaction~TransactionMap}
+   */
+  static responseMap = {
+    id: 'id',
+    cost: 'bidAmount',
+    scoringPeriodId: 'scoringPeriodId',
+    action: {
+      key: 'items',
+      manualParse: (responseData, data, constructorParams) => {
+        const item = _.find(responseData, { playerId: constructorParams.playerId });
+        return item.type;
+      }
+    },
+    fromTeamId: {
+      key: 'items',
+      manualParse: (responseData, data, constructorParams) => {
+        const item = _.find(responseData, { playerId: constructorParams.playerId });
+        return item.fromTeamId;
+      }
+    },
+    toTeamId: {
+      key: 'items',
+      manualParse: (responseData, data, constructorParams) => {
+        const item = _.find(responseData, { playerId: constructorParams.playerId });
+        return item.toTeamId;
+      }
+    },
+    isKeeper: {
+      key: 'items',
+      manualParse: (responseData, data, constructorParams) => {
+        const item = _.find(responseData, { playerId: constructorParams.playerId });
+        return item.isKeeper;
+      }
+    }
+  };
+
+  onPopulate() {
+    // Some hacky cleanup :-/
+    if (this.action === 'DROP' || this.action === 'TRADE') {
+      delete this.cost;
+    }
+    if (this.action !== 'DRAFT') {
+      delete this.isKeeper;
+    }
+  }
+}
+
+export default Transaction;

--- a/src/transaction/transaction.test.js
+++ b/src/transaction/transaction.test.js
@@ -1,0 +1,87 @@
+import BaseObject from '../base-classes/base-object/base-object.js';
+
+import Transaction from './transaction.js';
+import stafford from './testdata/stafford.json';
+import mixon from './testdata/mixon.json';
+
+describe('Transaction', () => {
+  test('extends BaseObject', () => {
+    const instance = new Transaction();
+    expect(instance).toBeInstanceOf(BaseObject);
+  });
+
+  describe('responseMap', () => {
+    describe('buildFromServer', () => {
+      test('non-keeper draft', () => {
+        const transaction = Transaction.buildFromServer(
+          stafford.transactions[0],
+          { playerId: stafford.playerId }
+        );
+        expect(transaction).toEqual({
+          id: 'b286e9e8-e8f3-445b-90c8-eed71719e265',
+          action: 'DRAFT',
+          cost: 2,
+          isKeeper: false,
+          scoringPeriodId: 1,
+          fromTeamId: 0,
+          toTeamId: 2
+        });
+      });
+
+      test('keeper draft', () => {
+        const transaction = Transaction.buildFromServer(mixon.transactions[0], {
+          playerId: mixon.playerId
+        });
+        expect(transaction).toEqual({
+          id: 'cb0cd39a-8abe-4448-80f1-4fece3a4628f',
+          action: 'DRAFT',
+          cost: 38,
+          isKeeper: true,
+          scoringPeriodId: 1,
+          fromTeamId: 0,
+          toTeamId: 6
+        });
+      });
+
+      test('waiver drop', () => {
+        const transaction = Transaction.buildFromServer(mixon.transactions[1], {
+          playerId: mixon.playerId
+        });
+        expect(transaction).toEqual({
+          id: 'd7e9dc4f-9b55-49eb-aa9c-5719505648e0',
+          action: 'DROP',
+          scoringPeriodId: 15,
+          fromTeamId: 6,
+          toTeamId: 0
+        });
+      });
+
+      test('free-agent add', () => {
+        const transaction = Transaction.buildFromServer(mixon.transactions[2], {
+          playerId: mixon.playerId
+        });
+        expect(transaction).toEqual({
+          id: 'cfe3c723-800e-4761-8654-b0c7e2f01eee',
+          action: 'ADD',
+          cost: 0,
+          scoringPeriodId: 16,
+          fromTeamId: 0,
+          toTeamId: 10
+        });
+      });
+
+      test('trade', () => {
+        const transaction = Transaction.buildFromServer(stafford.transactions[5], {
+          playerId: stafford.playerId
+        });
+        expect(transaction).toEqual({
+          id: '4f525632-bf58-4799-8596-926a6c6b8cdd',
+          action: 'TRADE',
+          scoringPeriodId: 6,
+          fromTeamId: 2,
+          toTeamId: 1
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This ingests transactions (ADD|DROP|TRADE|DRAFT) for all players from 2019 onwards